### PR TITLE
Display filename and hide localization and type object if null

### DIFF
--- a/src/app/home/description/description.component.html
+++ b/src/app/home/description/description.component.html
@@ -1,7 +1,14 @@
 <article *ngIf="mustBeLoaded">
 	<h2><span translate>Description</span></h2>
 	<div class="row">
-		<div class="col-md-6">
+		<div class="col-md-12">
+				<article>
+			<span class="h3 fa-file descriptionList" ><span translate>File</span> :</span>
+			<span >{{ currentSlide.name }}</span>
+			</article>
+		</div>
+
+		<div class="col-md-6" *ngIf="localisation">
 			<article>
 				<h3 class="waves-effect waves-teal fa-map-marker descriptionList"><span translate>Localisation</span></h3> 
 				<ul class="descriptionList">
@@ -11,7 +18,7 @@
 				</ul>
 			</article>
 		</div>
-		<div class="col-md-6">
+		<div class="col-md-6" *ngIf="object_type">
 			<article>
 				<h3 class="fa-cogs descriptionList"><span translate>TypeObject</span></h3> 
 				<ul class="descriptionList">

--- a/src/app/home/description/description.component.scss
+++ b/src/app/home/description/description.component.scss
@@ -74,7 +74,33 @@ article {
 			}
 		}
 	}
-	
+	.col-md-12 {
+		
+		margin-bottom: 1em;
+		article {
+		background-color: $white;		
+		border-radius: 5px;
+		box-shadow: 1px 1px 2px $gray;
+		padding: 1em;
+		margin: 1em 0;
+		min-height: 70px;
+		@include media-breakpoint-up(md) { 
+			min-height: auto;
+			height: 100%;
+			margin: 0;
+		}
+		.h3 {
+				
+			&:before {
+				@extend .fa;
+
+				margin-right: .3em; 
+				width: 30px;
+				text-align: center;
+			}
+		}
+	}
+	}
 	
 	.col-md-6 {
 		article {

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -7,9 +7,11 @@
   "Author": "Author",
   "Search": "Search a file",
   "Datacube": "Datacube plugin",
-  "Histogramme": "Histogram",
+  "Histogram": "Histogram",
+  "Reset Histogram": "Reset Histogram",
   "Spectre": "Spectre",
   "Description": "Description",
+  "File" : "File",
   "ResetPlot": "Reset Plot Spectre",
   "CubeSlider": "Cube depth",
   "Linear": "Linear",
@@ -41,5 +43,8 @@
   "PasswordRequired" : "Password is required",
   "Opacity" : "Opacity",
   "choiceColorscale" : "Color choice",
-  "SetSmooth" : "Set smooth"
+  "SetSmooth" : "Set smooth",
+  "Credits" : "Contributeurs",
+  "messageCreditsCNES" : "The CNES institute developped this sofware"
+  
 }

--- a/src/translations/fr-FR.json
+++ b/src/translations/fr-FR.json
@@ -7,9 +7,11 @@
   "Author": "Auteur",
   "Search": "Rechercher un fichier",
   "Datacube": "Plugin Datacube",
-  "Histogramme": "Histogramme",
+  "Histogram": "Histogramme",
+  "Reset Histogram": "Réinitialiser l'Histogramme",
   "Spectre": "Spectre",
   "Description": "Description",
+  "File" : "Fichier",
   "ResetPlot": "Supprimer Points",
   "CubeSlider": "Profondeur du Cube",
   "Linear": "Linéaire",
@@ -41,5 +43,6 @@
   "PasswordRequired" : "Mot de passe obligatoire",
   "Opacity" : "Opacité",
   "choiceColorscale" : "Choix de l'échelle de couleur",
-  "SetSmooth" : "Activer smooth"
+  "SetSmooth" : "Activer smooth",
+  "Credits" : "Credits"
 }


### PR DESCRIPTION
Here is a suggested fix for the redmine ticket [2783](https://idoc-projets.ias.u-psud.fr/redmine/issues/2783?issue_count=18&issue_position=3&next_issue_id=2779&prev_issue_id=2784)

As explained there it's hard to implement a generic way to get localization and object type from fits and netcdf. There is no convention for that yet and nothing in our files that can be used for that. 

So I suggest not displaying anything when the server doesn't have the information.
Karin thought it would be nice to display the filename in that area so I added a bit of html that does this.

**cf screencaps :**
with the file name alone :

![file_alone](https://user-images.githubusercontent.com/7287245/69640738-2a8c5980-105f-11ea-8c86-153e2a7c4d57.png)

file name with localization and type object:

![file_loc_and_to](https://user-images.githubusercontent.com/7287245/69640739-2a8c5980-105f-11ea-96fe-7bf57c8921be.png)

