### PR TITLE
Click on Metadata now works

### DIFF
--- a/src/app/home/description/description.component.html
+++ b/src/app/home/description/description.component.html
@@ -23,7 +23,7 @@
 		</div>
 	</div>
 	<div class="accordion accordionMetaData">
-		<h3 accordion class="fa-cubes descriptionList"><span translate>Metadata</span></h3> 
+		<h3 accordion class="fa-cubes descriptionList">{{ 'Metadata' | translate }}</h3> 
 		<div>
 			<ul class="descriptionList">
 				<li *ngFor="let list of metadatas">


### PR DESCRIPTION
The span tag prevented the accordion to open or close when clicking on it instead of the parent h tag.