### PR TITLE
Spectre and Histogram switch place

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -5,7 +5,7 @@
 	</div>	
 	<div class="row">
 		<app-data-cube  
-			class="col-md-8"
+			class="col-md-6"
 			[hidden]="isLoadingCube" 
 			(dataCubeLoadingStatus)="loadingChange($event)"
 			[newImage]="newImage"
@@ -14,8 +14,20 @@
 		>  
 		</app-data-cube>
 
+		<app-spectre 
+			class="col-md-6"
+			[hidden]="isLoadingSpectre" 
+			(spectreLoadingStatus)="loadingChange($event)"
+		>
+		</app-spectre>
+	</div>
+	<div class="row">
+		<app-loader class="col-md-6" [isLoading]="isLoadingSpectre" [message]="messageSpectreLoading"></app-loader>
+		<app-loader class="col-md-6" [isLoading]="isLoadingDesc" [message]="messageDescLoading"></app-loader>
+	</div>
+	<div class="row">
 		<app-histogram 
-			class="col-md-4"
+			class="col-md-6"
 			[hidden]="isLoadingHisto" 
 			(histoLoadingStatus)="loadingChange($event)"
 			(newImageEmitter)="loadingNewImage($event)" 
@@ -23,18 +35,6 @@
 			(newHmaxEmitter)="loadingNewHmax($event)"
 		>
 		</app-histogram>
-	</div>
-	<div class="row">
-		<app-loader class="col-md-6" [isLoading]="isLoadingSpectre" [message]="messageSpectreLoading"></app-loader>
-		<app-loader class="col-md-6" [isLoading]="isLoadingDesc" [message]="messageDescLoading"></app-loader>
-	</div>
-	<div class="row">
-		<app-spectre 
-			class="col-md-6"
-			[hidden]="isLoadingSpectre" 
-			(spectreLoadingStatus)="loadingChange($event)"
-		>
-		</app-spectre>
 
 		<app-description 
 			class="col-md-6"


### PR DESCRIPTION
When reading the spectre, one would like to see their emplacement on the image easily without having to scroll up and down all the time.
To fix this we put the Histogram down in place of the Spectre.
This fixes the redmine ticket 2889 - https://idoc-projets.ias.u-psud.fr/redmine/issues/2889

We get :
![image](https://user-images.githubusercontent.com/7287245/71822386-ff9d1880-3094-11ea-9c7d-f9d03b4562d0.png)

instead of this :
![image](https://user-images.githubusercontent.com/7287245/71822431-1e9baa80-3095-11ea-8754-5c9bb9b4f2c4.png)
